### PR TITLE
✨ support express-style routes definition such as "/foo/:bar"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,8 +47,10 @@ var staticize = new Staticize({
     }
   },
   routes: {
-    '/cache2s'    : 2,
-    'get /cache3s': 3
+    '/cache2s'    : 2,  // default GET method
+    'get /cache3s': 3,
+    'post /cache3s': 3,
+    'get /foo/:bar': 5, // match /foo/whatever
   }
 });
 ```

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "event-stream": "^3.3.2",
     "lodash": "^3.10.1",
     "memory-cache": "^0.1.4",
+    "path-to-regexp": "^1.7.0",
     "redis": "^2.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
1. 支持动态路由匹配
2. '/cache' 的定义只匹配get请求，不再匹配所有类型请求